### PR TITLE
Use gsub for whitespace replacement in bs_icon()

### DIFF
--- a/R/bs-icon.R
+++ b/R/bs-icon.R
@@ -47,7 +47,7 @@ bs_icon <- function(
     rlang::abort("The number of icons specified in `name` must be 1.")
   }
 
-  name <- sub("\\s+", "-", tolower(name))
+  name <- gsub("\\s+", "-", tolower(name))
   idx <- match(name, tolower(icon_info$name))
   if (is.na(idx)) {
     dists <- utils::adist(name, icon_info$name)


### PR DESCRIPTION
Currently, `bs_icon()` only replaces the first instance of whitespace with a dash, so a call such as `bs_icon("exclamation circle fill")` fails.

``` r
library(bsicons)

bs_icon("exclamation circle fill")
#> Error in `bs_icon()`:
#> ! This Bootstrap icon "exclamation-circle fill" does not exist.
#> ℹ Did you mean one of the following: "exclamation-circle-fill",
#>   "exclamation-circle", "exclamation-square-fill", "exclamation-triangle-fill",
#>   or "exclamation-diamond-fill"?
#> ℹ Try searching for the icon: <https://icons.getbootstrap.com>.

bs_icon("exclamation-circle-fill")
```

<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="bi bi-exclamation-circle-fill " style="height:1em;width:1em;fill:currentColor;vertical-align:-0.125em;" aria-hidden="true" role="img" ><path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8 4a.905.905 0 0 0-.9.995l.35 3.507a.552.552 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4zm.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2z"></path></svg>

<sup>Created on 2025-07-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This PR replaces the call to `sub()` in `bs_icon()` with `gsub()` in order to replace all instances of whitespace with dashes. 